### PR TITLE
Correct incorrect assignment

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -110,9 +110,9 @@ define restic::repository (
     config   => $config_file,
     configs  => $backup_keys,
     enable   => $enable_backup,
-    group    => $user,
+    group    => $group,
     timer    => $backup_timer,
-    user     => $group,
+    user     => $user,
   }
 
   ##


### PR DESCRIPTION
I changed ...
```
  restic::service { "restic_backup_${title}":
    commands => $backup_commands.delete_undef_values,
    config   => $config_file,
    configs  => $backup_keys,
    enable   => $enable_backup,
    group    => $user,
    timer    => $backup_timer,
    user     => $group,
  }
```

to ...
```
  restic::service { "restic_backup_${title}":
    commands => $backup_commands.delete_undef_values,
    config   => $config_file,
    configs  => $backup_keys,
    enable   => $enable_backup,
    group    => $group,
    timer    => $backup_timer,
    user     => $user,
  }
```

which ...
fixes issue #2